### PR TITLE
feat(react-native-plugin): Convert package into a React Native plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you would like to contribute through writing code, here's a guide on how to m
 3. Clone the repository to your local machine using `git clone https://github.com/YOUR_USERNAME_HERE/react-native-create-bridge.git`.
 4. Create a new branch for your fix using `git checkout -b branch-name-here`.
 5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add. If you are adding a feature or changing functionality, please write tests! 👍 Tests will help your PR get merged faster.
-6. Test your change locally by running `npm run package:dev`. This command will build the project and create a symlink. In a test project, run `npm link react-native-create-bridge` which will link to your local copy. Then, you can run `react-native new-module` to test your change.
+6. Test your change locally by running `npm run package:dev`. This command will build the project and create a symlink. In a test project, run `npm install --save react-native-create-bridge && npm link react-native-create-bridge` which will link to your local copy. Then, you can run `react-native new-module` to test your change.
 7. Confirm that tests still pass by running `npm run test`. If the tests are failing, please ask for help!
 8. Add and commit the changed files using `git add` and `git commit`. We use [Conventional Changelog Standard](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) for our commit messages. More info on that below.
 9. Push the changes to the remote repository using git push origin branch-name-here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you would like to contribute through writing code, here's a guide on how to m
 3. Clone the repository to your local machine using `git clone https://github.com/YOUR_USERNAME_HERE/react-native-create-bridge.git`.
 4. Create a new branch for your fix using `git checkout -b branch-name-here`.
 5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add. If you are adding a feature or changing functionality, please write tests! 👍 Tests will help your PR get merged faster.
-6. Test your change locally by running `npm run package:dev`. This command will build the project and create a symlink. In a test project, run `npm link react-native-create-bridge` which will link to your local copy. Then, you can run `create-bridge` to test your change.
+6. Test your change locally by running `npm run package:dev`. This command will build the project and create a symlink. In a test project, run `npm link react-native-create-bridge` which will link to your local copy. Then, you can run `react-native new-module` to test your change.
 7. Confirm that tests still pass by running `npm run test`. If the tests are failing, please ask for help!
 8. Add and commit the changed files using `git add` and `git commit`. We use [Conventional Changelog Standard](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) for our commit messages. More info on that below.
 9. Push the changes to the remote repository using git push origin branch-name-here.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Bridging native modules & UI components made easy! If you're a JavaScript developer writing your first lines of native code or a more experienced developer looking to eliminate boilerplate from your React Native workflow, this tool is for you.
 
 ## Getting Started
-1. `npm install -g react-native-create-bridge` or `yarn global add react-native-create-bridge`
-2. From the root of your React Native project, run `create-bridge`
+1. `npm install -s react-native-create-bridge` or `yarn add react-native-create-bridge`
+2. From the root of your React Native project, run `react-native create-bridge`
 3. The prompts will ask you for:
   - Your bridge module name
   - Whether you want to create a native module or UI component (or both!)
@@ -48,7 +48,7 @@ Depending on your environment, there may be a couple more steps that you have to
   }
   ```
   - Import your package at the top: `import com.yourapp.yourmodule.YourModulePackage`
-  
+
 #### iOS/Obj-C
   - Currently, you will need to add the files manually to your project in Xcode. Right click on the folder with your app name and select `Add Files To YourApp`. Select the files associated with your module and click `Add`
 
@@ -69,7 +69,7 @@ Depending on your environment, there may be a couple more steps that you have to
 2. `cd` to where you cloned it
 3. `npm install` or `yarn`
 4. After you make changes, link your local package by running `npm run package:dev`
-5. You can now run `create-bridge` locally in a React Native project to test your changes
+5. You can now run `react-native create-bridge` locally in a React Native project to test your changes
 6. `npm run test` will run the Jest test suite
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Bridging native modules & UI components made easy! If you're a JavaScript developer writing your first lines of native code or a more experienced developer looking to eliminate boilerplate from your React Native workflow, this tool is for you.
 
 ## Getting Started
-1. `npm install -s react-native-create-bridge` or `yarn add react-native-create-bridge`
+1. `npm install --save react-native-create-bridge` or `yarn add react-native-create-bridge`
 2. From the root of your React Native project, run `react-native create-bridge`
 3. The prompts will ask you for:
   - Your bridge module name

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bridging native modules & UI components made easy! If you're a JavaScript develo
 
 ## Getting Started
 1. `npm install --save react-native-create-bridge` or `yarn add react-native-create-bridge`
-2. From the root of your React Native project, run `react-native create-bridge`
+2. From the root of your React Native project, run `react-native new-module`
 3. The prompts will ask you for:
   - Your bridge module name
   - Whether you want to create a native module or UI component (or both!)
@@ -68,7 +68,7 @@ Depending on your environment, there may be a couple more steps that you have to
 2. `cd` to where you cloned it
 3. `npm install` or `yarn`
 4. After you make changes, link your local package by running `npm run package:dev`
-5. You can now run `react-native create-bridge` locally in a React Native project to test your changes
+5. You can now run `react-native new-module` locally in a React Native project to test your changes
 6. `npm run test` will run the Jest test suite
 
 ## Contributing

--- a/__tests__/android-java.js
+++ b/__tests__/android-java.js
@@ -1,5 +1,6 @@
 import path from 'path';
-import { readFile, parseFile } from '../src/file-operations';
+const fileOperations = require('../src/file-operations');
+const { readFile, parseFile } = fileOperations;
 
 describe('Android/Java: UI Components', () => {
   const templateName = 'TestModule';

--- a/__tests__/android-kotlin.js
+++ b/__tests__/android-kotlin.js
@@ -1,5 +1,6 @@
 import path from 'path';
-import { readFile, parseFile } from '../src/file-operations';
+const fileOperations = require('../src/file-operations');
+const { readFile, parseFile } = fileOperations;
 
 describe('Android/Kotlin: UI Components', () => {
   const templateName = 'TestModule';

--- a/__tests__/ios-objc.test.js
+++ b/__tests__/ios-objc.test.js
@@ -1,5 +1,6 @@
 import path from 'path';
-import { readFile, parseFile } from '../src/file-operations';
+const fileOperations = require('../src/file-operations');
+const { readFile, parseFile } = fileOperations;
 
 describe('iOS/Obj-C: UI Components', () => {
   const templateName = 'TestModule';

--- a/__tests__/ios-swift.test.js
+++ b/__tests__/ios-swift.test.js
@@ -1,5 +1,7 @@
 import path from 'path';
-import { readFile, parseFile } from '../src/file-operations';
+
+const fileOperations = require('../src/file-operations');
+const { readFile, parseFile } = fileOperations;
 
 describe('iOS/Swift: UI Components', () => {
   const templateName = 'TestModule';

--- a/__tests__/javascript.test.js
+++ b/__tests__/javascript.test.js
@@ -1,5 +1,6 @@
 import path from 'path';
-import { readFile, parseFile } from '../src/file-operations';
+const fileOperations = require('../src/file-operations');
+const { readFile, parseFile } = fileOperations;
 
 describe('JS: Combined', () => {
   const templateName = 'TestModule';

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "plugins": ["transform-runtime"]
   },
   "rnpm": {
-    "plugin:": "./src/index.js"
+    "plugin": "./src/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
       ]
     ],
     "plugins": ["transform-runtime"]
+  },
+  "rnpm": {
+    "plugin:": "./src/index.js"
   }
 }

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -3,29 +3,24 @@ const fs = require("mz/fs");
 
 exports.pkg = require(path.join(process.cwd(), "package.json"));
 
-exports.getFileNames = function getFileNames(dirPath) {
+function getFileNames(dirPath) {
   return fs.readdir(dirPath).catch(e => console.error("[getFileNames] ", e));
-};
+}
 
-exports.readFile = function readFile(file, readDirPath) {
+function readFile(file, readDirPath) {
   return fs
     .readFile(path.join(readDirPath, file), "utf-8")
     .catch(e => console.error("[readFile] ", e));
-};
+}
 
-exports.parseFile = function parseFile(
-  fileData,
-  templateName,
-  packageName = null,
-  app = null
-) {
+function parseFile(fileData, templateName, packageName = null, app = null) {
   return fileData
     .replace(/{{template}}/g, templateName)
     .replace(/{{packageName}}/g, packageName)
     .replace(/{{app}}/g, app);
-};
+}
 
-module.exports = function readAndWriteFiles(
+function readAndWriteFiles(
   files,
   paths,
   templateName,
@@ -42,4 +37,11 @@ module.exports = function readAndWriteFiles(
       });
     })
   ).catch(e => console.error("[readAndWriteFiles] ", e));
+}
+
+module.exports = {
+  getFileNames,
+  readFile,
+  parseFile,
+  readAndWriteFiles
 };

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("mz/fs");
 
-exports.pkg = require(path.join(process.cwd(), "package.json"));
+const pkg = require(path.join(process.cwd(), "package.json"));
 
 function getFileNames(dirPath) {
   return fs.readdir(dirPath).catch(e => console.error("[getFileNames] ", e));
@@ -40,6 +40,7 @@ function readAndWriteFiles(
 }
 
 module.exports = {
+  pkg,
   getFileNames,
   readFile,
   parseFile,

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -1,23 +1,19 @@
-import path from "path";
-import fs from "mz/fs";
+const path = require("path");
+const fs = require("mz/fs");
 
-export const pkg = require(path.join(process.cwd(), "package.json"));
+exports.pkg = require(path.join(process.cwd(), "package.json"));
 
-export async function getFileNames(dirPath) {
-  const fileNames = await fs
-    .readdir(dirPath)
-    .catch(e => console.error("[getFileNames] ", e));
-  return fileNames;
-}
+exports.getFileNames = function getFileNames(dirPath) {
+  return fs.readdir(dirPath).catch(e => console.error("[getFileNames] ", e));
+};
 
-export async function readFile(file, readDirPath) {
-  const fileData = await fs
+exports.readFile = function readFile(file, readDirPath) {
+  return fs
     .readFile(path.join(readDirPath, file), "utf-8")
     .catch(e => console.error("[readFile] ", e));
-  return fileData;
-}
+};
 
-export function parseFile(
+exports.parseFile = function parseFile(
   fileData,
   templateName,
   packageName = null,
@@ -27,9 +23,9 @@ export function parseFile(
     .replace(/{{template}}/g, templateName)
     .replace(/{{packageName}}/g, packageName)
     .replace(/{{app}}/g, app);
-}
+};
 
-export default function readAndWriteFiles(
+module.exports = function readAndWriteFiles(
   files,
   paths,
   templateName,
@@ -38,11 +34,12 @@ export default function readAndWriteFiles(
 ) {
   const { readDirPath, writeDirPath } = paths;
   return Promise.all(
-    files.map(async file => {
-      const fileData = await readFile(file, readDirPath);
-      const parsedFile = parseFile(fileData, templateName, packageName, app);
-      const fileName = file.replace("Template", templateName);
-      return fs.writeFile(path.join(writeDirPath, fileName), parsedFile);
+    files.map(file => {
+      readFile(file, readDirPath).then(fileData => {
+        const parsedFile = parseFile(fileData, templateName, packageName, app);
+        const fileName = file.replace("Template", templateName);
+        return fs.writeFile(path.join(writeDirPath, fileName), parsedFile);
+      });
     })
   ).catch(e => console.error("[readAndWriteFiles] ", e));
-}
+};

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -50,21 +50,14 @@ function parseFile(fileData, { templateName, packageName, app, rnVersion }) {
 function readAndWriteFiles(files, paths, config) {
   const { readDirPath, writeDirPath } = paths;
   return Promise.all(
-    files
-      .map(file => {
-        readFile(file, readDirPath).then(fileData => {
-          const parsedFile = parseFile(
-            fileData,
-            templateName,
-            packageName,
-            app
-          );
-          const fileName = file.replace("Template", templateName);
-          return fs.writeFile(path.join(writeDirPath, fileName), parsedFile);
-        });
-      })
-      .catch(e => console.error("[readAndWriteFiles] ", e))
-  );
+    files.map(file => {
+      readFile(file, readDirPath).then(fileData => {
+        const parsedFile = parseFile(fileData, config);
+        const fileName = file.replace("Template", config.templateName);
+        return fs.writeFile(path.join(writeDirPath, fileName), parsedFile);
+      });
+    })
+  ).catch(e => console.error("[readAndWriteFiles] ", e));
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const logSymbols = require("log-symbols");
 const successIcon = logSymbols.success;
 const errorIcon = logSymbols.error;
 
-const readAndWriteFiles = require("./file-operations");
-const { pkg, getFileNames } = readAndWriteFiles;
+const fileOperations = require("./file-operations");
+const { pkg, getFileNames, readAndWriteFiles } = fileOperations;
 
 const templateNameRegex = /\w+/;
 const promptConfig = [

--- a/src/index.js
+++ b/src/index.js
@@ -99,26 +99,24 @@ function createJavaEnvironment(templateName, templateFolder) {
     "android-java"
   );
 
-  return mkdir(
-    path.join(appPath, templateName.toLowerCase()).then(writeDirPath => {
-      const paths = {
-        readDirPath,
-        writeDirPath: writeDirPath
-          ? writeDirPath
-          : path.join(appPath, templateName.toLowerCase())
-      };
+  mkdir(path.join(appPath, templateName.toLowerCase())).then(writeDirPath => {
+    const paths = {
+      readDirPath,
+      writeDirPath: writeDirPath
+        ? writeDirPath
+        : path.join(appPath, templateName.toLowerCase())
+    };
 
-      return getFileNames(readDirPath).then(files =>
-        readAndWriteFiles(
-          files,
-          paths,
-          templateName,
-          templateName.toLowerCase(),
-          pkg.name.toLowerCase()
-        )
-      );
-    })
-  );
+    getFileNames(readDirPath).then(files =>
+      readAndWriteFiles(
+        files,
+        paths,
+        templateName,
+        templateName.toLowerCase(),
+        pkg.name.toLowerCase()
+      )
+    );
+  });
 }
 
 function createKotlinEnvironment(templateName, templateFolder) {

--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,10 @@ async function init() {
       jsPath
     } = await inquirer.prompt(promptConfig);
 
-    const templateFolder = bridgeType.length > 1
-      ? "combined"
-      : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
+    const templateFolder =
+      bridgeType.length > 1
+        ? "combined"
+        : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
 
     const promises = environment.map(env =>
       environmentMap[env](templateName, templateFolder)
@@ -220,4 +221,9 @@ async function createJSEnvironment(templateName, templateFolder, jsPath) {
   return readAndWriteFiles(files, paths, templateName);
 }
 
-init();
+module.exports = {
+  name: "create-bridge",
+  description:
+    "generates boilerplate native code templates to be bridged to react native",
+  run: init
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-#! /usr/bin/env node
 const inquirer = require("inquirer");
 const path = require("path");
 const isValid = require("is-valid-path");
@@ -73,14 +72,14 @@ function init() {
         );
       });
     })
-    .catch(() => {
+    .catch(e => {
       console.log(
         `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
       );
     });
 }
 
-async function createJavaEnvironment(templateName, templateFolder) {
+function createJavaEnvironment(templateName, templateFolder) {
   const appPath = path.join(
     process.cwd(),
     "android",
@@ -100,29 +99,29 @@ async function createJavaEnvironment(templateName, templateFolder) {
     "android-java"
   );
 
-  const writeDirPath = await mkdir(
-    path.join(appPath, templateName.toLowerCase())
-  );
+  return mkdir(
+    path.join(appPath, templateName.toLowerCase()).then(writeDirPath => {
+      const paths = {
+        readDirPath,
+        writeDirPath: writeDirPath
+          ? writeDirPath
+          : path.join(appPath, templateName.toLowerCase())
+      };
 
-  const paths = {
-    readDirPath,
-    writeDirPath: writeDirPath
-      ? writeDirPath
-      : path.join(appPath, templateName.toLowerCase())
-  };
-
-  const files = await getFileNames(readDirPath);
-
-  return readAndWriteFiles(
-    files,
-    paths,
-    templateName,
-    templateName.toLowerCase(),
-    pkg.name.toLowerCase()
+      return getFileNames(readDirPath).then(files =>
+        readAndWriteFiles(
+          files,
+          paths,
+          templateName,
+          templateName.toLowerCase(),
+          pkg.name.toLowerCase()
+        )
+      );
+    })
   );
 }
 
-async function createKotlinEnvironment(templateName, templateFolder) {
+function createKotlinEnvironment(templateName, templateFolder) {
   const appPath = path.join(
     process.cwd(),
     "android",
@@ -142,29 +141,29 @@ async function createKotlinEnvironment(templateName, templateFolder) {
     "android-kotlin"
   );
 
-  const writeDirPath = await mkdir(
+  return mkdir(
     path.join(appPath, templateName.toLowerCase())
-  );
+  ).then(writeDirPath => {
+    const paths = {
+      readDirPath,
+      writeDirPath: writeDirPath
+        ? writeDirPath
+        : path.join(appPath, templateName.toLowerCase())
+    };
 
-  const paths = {
-    readDirPath,
-    writeDirPath: writeDirPath
-      ? writeDirPath
-      : path.join(appPath, templateName.toLowerCase())
-  };
-
-  const files = await getFileNames(readDirPath);
-
-  return readAndWriteFiles(
-    files,
-    paths,
-    templateName,
-    templateName.toLowerCase(),
-    pkg.name.toLowerCase()
-  );
+    return getFileNames(readDirPath).then(files =>
+      readAndWriteFiles(
+        files,
+        paths,
+        templateName,
+        templateName.toLowerCase(),
+        pkg.name.toLowerCase()
+      )
+    );
+  });
 }
 
-async function createSwiftEnvironment(templateName, templateFolder) {
+function createSwiftEnvironment(templateName, templateFolder) {
   const readDirPath = path.join(
     __dirname,
     "..",
@@ -178,12 +177,12 @@ async function createSwiftEnvironment(templateName, templateFolder) {
     writeDirPath: path.join(process.cwd(), "ios")
   };
 
-  const files = await getFileNames(readDirPath);
-
-  return readAndWriteFiles(files, paths, templateName);
+  return getFileNames(readDirPath).then(files =>
+    readAndWriteFiles(files, paths, templateName)
+  );
 }
 
-async function createObjCEnvironment(templateName, templateFolder) {
+function createObjCEnvironment(templateName, templateFolder) {
   const readDirPath = path.join(
     __dirname,
     "..",
@@ -197,12 +196,12 @@ async function createObjCEnvironment(templateName, templateFolder) {
     writeDirPath: path.join(process.cwd(), "ios")
   };
 
-  const files = await getFileNames(readDirPath);
-
-  return readAndWriteFiles(files, paths, templateName);
+  return getFileNames(readDirPath).then(files =>
+    readAndWriteFiles(files, paths, templateName)
+  );
 }
 
-async function createJSEnvironment(templateName, templateFolder, jsPath) {
+function createJSEnvironment(templateName, templateFolder, jsPath) {
   const readDirPath = path.join(
     __dirname,
     "..",
@@ -211,21 +210,21 @@ async function createJSEnvironment(templateName, templateFolder, jsPath) {
     "js"
   );
 
-  await mkdir(jsPath);
+  return mkdir(jsPath).then(() => {
+    const paths = {
+      readDirPath,
+      writeDirPath: jsPath
+    };
 
-  const paths = {
-    readDirPath,
-    writeDirPath: jsPath
-  };
-
-  const files = await getFileNames(readDirPath);
-
-  return readAndWriteFiles(files, paths, templateName);
+    return getFileNames(readDirPath).then(files =>
+      readAndWriteFiles(files, paths, templateName)
+    );
+  });
 }
 
 module.exports = {
   name: "create-bridge",
   description:
-    "generates boilerplate native code templates to be bridged to react native",
-  run: init
+    "A CLI tool that bridges React Native modules & UI components with ease",
+  func: init
 };

--- a/src/index.js
+++ b/src/index.js
@@ -56,10 +56,9 @@ function init() {
     .then(result => {
       const { environment, bridgeType, templateName, jsPath } = result;
 
-      const templateFolder =
-        bridgeType.length > 1
-          ? "combined"
-          : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
+      const templateFolder = bridgeType.length > 1
+        ? "combined"
+        : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
 
       const promises = environment.map(env =>
         environmentMap[env](templateName, templateFolder)
@@ -222,8 +221,7 @@ function createJSEnvironment(templateName, templateFolder, jsPath) {
 }
 
 module.exports = {
-  name: "create-bridge",
-  description:
-    "A React Native plugin that bridges React Native modules & UI components with ease",
+  name: "new-module",
+  description: "bridges React Native modules & UI components with ease",
   func: init
 };

--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,6 @@ function createJSEnvironment(templateName, templateFolder, jsPath) {
 
 module.exports = {
   name: "new-module",
-  description: "bridges React Native modules & UI components with ease",
+  description: "bridges React Native modules & UI components",
   func: init
 };

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,12 @@ const environmentMap = {
   "iOS/Objective-C": createObjCEnvironment
 };
 
+function logError() {
+  console.log(
+    `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
+  );
+}
+
 function init() {
   inquirer
     .prompt(promptConfig)
@@ -74,15 +80,11 @@ function init() {
           );
         })
         .catch(() => {
-          console.log(
-            `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
-          );
+          logError();
         });
     })
     .catch(() => {
-      console.log(
-        `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
-      );
+      logError();
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,9 @@ function createJavaEnvironment(templateName, templateFolder) {
     "android-java"
   );
 
-  mkdir(path.join(appPath, templateName.toLowerCase())).then(writeDirPath => {
+  return mkdir(
+    path.join(appPath, templateName.toLowerCase())
+  ).then(writeDirPath => {
     const paths = {
       readDirPath,
       writeDirPath: writeDirPath

--- a/src/index.js
+++ b/src/index.js
@@ -50,12 +50,6 @@ const environmentMap = {
   "iOS/Objective-C": createObjCEnvironment
 };
 
-function logError() {
-  console.log(
-    `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
-  );
-}
-
 function init() {
   inquirer
     .prompt(promptConfig)
@@ -73,18 +67,16 @@ function init() {
 
       promises.push(createJSEnvironment(templateName, templateFolder, jsPath));
 
-      Promise.all(promises)
-        .then(() => {
-          console.log(
-            `${successIcon} Your bridge module was successfully created! 🎉`
-          );
-        })
-        .catch(() => {
-          logError();
-        });
+      Promise.all(promises).then(() => {
+        console.log(
+          `${successIcon} Your bridge module was successfully created! 🎉`
+        );
+      });
     })
     .catch(() => {
-      logError();
+      console.log(
+        `${errorIcon} Oh no! 💩  Something went wrong with creating your bridge module.\nPlease report any errors here: https://github.com/peggyrayzis/react-native-create-bridge/issues\n\nError: ${e}`
+      );
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,7 @@ const isValid = require("is-valid-path");
 const mkdir = require("mkdirp-promise");
 const logSymbols = require("log-symbols");
 
-const successIcon = logSymbols.success;
-const errorIcon = logSymbols.error;
+const { successIcon, errorIcon } = logSymbols;
 
 const fileOperations = require("./file-operations");
 const { pkg, getFileNames, readAndWriteFiles } = fileOperations;

--- a/src/index.js
+++ b/src/index.js
@@ -225,6 +225,6 @@ function createJSEnvironment(templateName, templateFolder, jsPath) {
 module.exports = {
   name: "create-bridge",
   description:
-    "A CLI tool that bridges React Native modules & UI components with ease",
+    "A React Native plugin that bridges React Native modules & UI components with ease",
   func: init
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const isValid = require("is-valid-path");
 const mkdir = require("mkdirp-promise");
 const logSymbols = require("log-symbols");
 
-const { successIcon, errorIcon } = logSymbols;
+const { success: successIcon, error: errorIcon } = logSymbols;
 
 const fileOperations = require("./file-operations");
 const { pkg, getFileNames, readAndWriteFiles } = fileOperations;


### PR DESCRIPTION
## What: Solving issue https://github.com/peggyrayzis/react-native-create-bridge/issues/19

## Why: This change allows for package to be installed and used locally within projects by use of `react-native create-bridge`

## How: 
  * Adding rnpm plugin path to `package.json`
  * Adding necessary `module.exports` to `index.js`
  * Refactor `index.js` and `file-operations.js` to use `require` and promise based functions
  * Refactor test files to import `fileOperations` with `require`


## Checklist:
- [x] I read the [contributor guidelines](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md)
- [x] My commit messages & PR title follow [Conventional Changelog Standard](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md#how-should-i-format-my-commit-messages)
- [x] I added tests for my new feature
- [x] I added documentation for my new feature
