### PR TITLE
update for ios-objc template

### DIFF
--- a/templates/modules/ios-objc/Template.m
+++ b/templates/modules/ios-objc/Template.m
@@ -55,7 +55,8 @@ RCT_EXPORT_METHOD(exampleMethod)
 // Implement methods that you want to export to the native module
 - (void) emitMessageToRN: (NSString *)eventName :(NSDictionary *)params {
   // The bridge eventDispatcher is used to send events from native to JS env
-  // No documentation yet on DeviceEventEmitter: https://github.com/facebook/react-native/issues/2819
+  // Documentation on DeviceEventEmitter:
+  // https://facebook.github.io/react-native/docs/native-modules-android.html#sending-events-to-javascript
   [self sendEventWithName: eventName body: params];
 }
 


### PR DESCRIPTION
The issue mentioned in this [template](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/templates/modules/ios-objc/Template.m#L58) is now closed.

```
// The bridge eventDispatcher is used to send events from native to JS env
// No documentation yet on DeviceEventEmitter: https://github.com/facebook/react-native/issues/2819
```

It was solved by [this commit](https://github.com/yk3372/react-native/commit/75916c1fa0a02280e53bb035544020668eceeeef) and is available in the [docs](https://facebook.github.io/react-native/docs/native-modules-android.html#sending-events-to-javascript).

Thanks.