### PR TITLE
[WIP]hotfix/invalid-semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "build:watch": "babel -w src --out-dir build",
     "start": "node build/index.js",
     "precommit": "lint-staged",
-    "package:dev":
-      "npm unlink react-native-create-bridge && rm -rf node_modules && yarn && npm run build && npm link"
+    "package:dev": "npm unlink react-native-create-bridge && rm -rf node_modules && yarn && npm run build && npm link"
   },
   "lint-staged": {
-    "src/*.js": ["prettier --write", "git add"]
+    "src/*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "bin": {
     "create-bridge": "build/index.js"
@@ -23,14 +25,16 @@
     "type": "git",
     "url": "git+https://github.com/peggyrayzis/react-native-create-bridge.git"
   },
-  "keywords": ["react", "native"],
+  "keywords": [
+    "react",
+    "native"
+  ],
   "author": "Peggy Rayzis & Kurt Kemple",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/peggyrayzis/react-native-create-bridge/issues"
   },
-  "homepage":
-    "https://github.com/peggyrayzis/react-native-create-bridge#readme",
+  "homepage": "https://github.com/peggyrayzis/react-native-create-bridge#readme",
   "dependencies": {
     "babel-runtime": "^6.20.0",
     "compare-versions": "^3.0.1",
@@ -38,7 +42,8 @@
     "is-valid-path": "^0.1.1",
     "log-symbols": "^1.0.2",
     "mkdirp-promise": "^5.0.0",
-    "mz": "^2.6.0"
+    "mz": "^2.6.0",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -63,6 +68,8 @@
         }
       ]
     ],
-    "plugins": ["transform-runtime"]
+    "plugins": [
+      "transform-runtime"
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,12 @@ import inquirer from "inquirer";
 import path from "path";
 import isValid from "is-valid-path";
 import mkdir from "mkdirp-promise";
+import semver from "semver";
 import { success as successIcon, error as errorIcon } from "log-symbols";
 
 import readAndWriteFiles, { pkg, getFileNames } from "./file-operations";
 
-const rnVersion = pkg.dependencies["react-native"];
+const rnVersion = semver.clean(pkg.dependencies["react-native"]);
 
 const templateNameRegex = /\w+/;
 const promptConfig = [
@@ -58,9 +59,10 @@ async function init() {
       jsPath
     } = await inquirer.prompt(promptConfig);
 
-    const templateFolder = bridgeType.length > 1
-      ? "combined"
-      : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
+    const templateFolder =
+      bridgeType.length > 1
+        ? "combined"
+        : bridgeType[0] === "Native Module" ? "modules" : "ui-components";
 
     const promises = environment.map(env =>
       environmentMap[env](templateName, templateFolder)


### PR DESCRIPTION
## What: Solving issue https://github.com/peggyrayzis/react-native-create-bridge/issues/36

## Why: This change fixes an issue where the React Native version wasn't in a correct format for `compare-versions` package (ie `^0.49.3` vs `0.49.3`).

## How: 
  * Adding semver package dependency `package.json`
  * Clean React Native version with `semver.clean`


## Checklist:
- [x] I read the [contributor guidelines](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md)
- [x] My commit messages & PR title follow [Conventional Changelog Standard](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md#how-should-i-format-my-commit-messages)
- [] I added tests for my new feature
- [x] I added documentation for my new feature
