### PR TITLE
fix(ios): renamed exported example iOS constant to be consistent with other templates

### DIFF
--- a/__tests__/__snapshots__/ios-objc.test.js.snap
+++ b/__tests__/__snapshots__/ios-objc.test.js.snap
@@ -53,7 +53,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @\\"EXAMPLE\\": @\\"example\\"
+           @\\"EXAMPLE_CONSTANT\\": @\\"example\\"
          };
 }
 
@@ -145,7 +145,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @\\"EXAMPLE\\": @\\"example\\"
+           @\\"EXAMPLE_CONSTANT\\": @\\"example\\"
          };
 }
 
@@ -285,7 +285,7 @@ RCT_EXPORT_VIEW_PROPERTY(exampleProp, NSString)
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @\\"EXAMPLE\\": @\\"example\\"
+           @\\"EXAMPLE_CONSTANT\\": @\\"example\\"
          };
 }
 

--- a/templates/combined/ios-objc/TemplateManager.m
+++ b/templates/combined/ios-objc/TemplateManager.m
@@ -32,7 +32,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"EXAMPLE": @"example"
+           @"EXAMPLE_CONSTANT": @"example"
          };
 }
 

--- a/templates/modules/ios-objc/Template.m
+++ b/templates/modules/ios-objc/Template.m
@@ -32,7 +32,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"EXAMPLE": @"example"
+           @"EXAMPLE_CONSTANT": @"example"
          };
 }
 

--- a/templates/ui-components/ios-objc/TemplateManager.m
+++ b/templates/ui-components/ios-objc/TemplateManager.m
@@ -34,7 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(exampleProp, NSString)
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"EXAMPLE": @"example"
+           @"EXAMPLE_CONSTANT": @"example"
          };
 }
 


### PR DESCRIPTION
## What:

Exported iOS example constant is inconsistent with other templates

## Why:

Using the example generated iOS bridge will export a different example constant than the other templates, which may be a cause of confusion for new users.

## How:

Updated the iOS templates to rename the exported constant.

## Checklist:
- [x] I read the [contributor guidelines](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md)
- [x] My commit messages & PR title follow [Conventional Changelog Standard](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md#how-should-i-format-my-commit-messages)
- [x] I added tests for my new feature
- [ ] I added documentation for my new feature

I've recently created a bridge library using this project and I noticed the exported example constant wasn't matching between iOS and Android. It had me confused for a few moments while I was trying to figure out why iOS wasn't giving me the expected value. I wasn't sure whether this was intentional or not, so if it's not I thought I'd submit this PR to correct it.