### PR TITLE
fix(requiresMainQueueSetup): stop warning requiresMainQueueSetup #59

### DIFF
--- a/__tests__/__snapshots__/ios-objc.test.js.snap
+++ b/__tests__/__snapshots__/ios-objc.test.js.snap
@@ -289,6 +289,11 @@ RCT_EXPORT_VIEW_PROPERTY(exampleProp, NSString)
          };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end
 "
 `;

--- a/templates/ui-components/ios-objc/TemplateManager.m
+++ b/templates/ui-components/ios-objc/TemplateManager.m
@@ -38,4 +38,9 @@ RCT_EXPORT_VIEW_PROPERTY(exampleProp, NSString)
          };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
#59

<!--
Thanks for your interest in the project. I appreciate and welcome all PRs submitted!

Please fill out the information below to expedite your PR review 😀
-->

<!-- What changes are being made? (What feature/bug is being fixed here? Please include issue number if you are closing an issue.) -->
## What:
i added requiresMainQueueSetup method to templates/ui-components/ios-objc/TemplateManager.m

<!-- Why are these changes necessary? -->
## Why:
because with the latest version of react native, we are getting warning "requiresMainQueueSetup"

<!-- How were these changes implemented? -->
## How:
i made new branch as mention in contributor docs and i added requiresMainQueueSetup method to templates/ui-components/ios-objc/TemplateManager.m after that i run npm run test after that update test by npm test -- -u && npm run test and after that i tested on my project
 

## Checklist:
<!-- to check an item, place an "x" in the box  -->
- [x] I read the [contributor guidelines](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md)
- [x] My commit messages & PR title follow [Conventional Changelog Standard](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md#how-should-i-format-my-commit-messages)
- [x] I added tests for my new feature
- [ ] I added documentation for my new feature

<!-- feel free to add additional comments -->
