### PR TITLE
Remove deprecated rnpm config from package.json in favour of react-native.config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,5 @@
     "plugins": [
       "transform-runtime"
     ]
-  },
-  "rnpm": {
-    "plugin": "./build/index.js"
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  commands: require('./build/index.js')
+}


### PR DESCRIPTION
## What:

Fixes a deprecated method of config as described by this issue https://github.com/peggyrayzis/react-native-create-bridge/issues/63 using the upgrade guide here https://github.com/react-native-community/cli/blob/master/docs/configuration.md\#migration-guide


<!-- Why are these changes necessary? -->
## Why:

The `rnpm` property in package.json is deprecated and will be removed in the next release of `react-native-community/cli`

<!-- How were these changes implemented? -->
## How:

- Removed `rnpm` from package.json
- Added react-native.config.js

## Checklist:
<!-- to check an item, place an "x" in the box  -->
- [x] I read the [contributor guidelines](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md)
- [x] My commit messages & PR title follow [Conventional Changelog Standard](https://github.com/peggyrayzis/react-native-create-bridge/blob/master/CONTRIBUTING.md#how-should-i-format-my-commit-messages)
- [x] I added tests for my new feature
- [x] I added documentation for my new feature

<!-- feel free to add additional comments -->
